### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,11 @@
         return set(obj, path.split('.').map(getKey), value, doNotReplace);
       }
       var currentPath = path[0];
+
+      if (currentPath === '__proto__' || currentPath === 'constructor' || currentPath === 'prototype') {
+        return obj;
+      }
+
       var currentValue = getShallowProperty(obj, currentPath);
       if (path.length === 1) {
         if (currentValue === void 0 || !doNotReplace) {


### PR DESCRIPTION
### 📊 Metadata *

object-path is a tiny JavaScript utility to access deep properties using a path (for Node and the Browser).

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-object-path


#### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Install the package(npm i object-path), run the below code:

```
var objectPath = require("object-path");

var obj = {};
console.log("Before: " + obj.polluted);
objectPath.set(obj, "__proto__.polluted", "pwned!"); 
console.log("After: " + obj.polluted);
```

2. Outputs pwned!.

![Captura de pantalla de 2020-09-23 19-51-52](https://user-images.githubusercontent.com/7505980/94044009-432be400-fdd6-11ea-8c54-4e23df4e872a.png)

### 🔥 Proof of Fix (PoF) *

After fix execution obj prototype is unmodified, undefined is returned

![Captura de pantalla de 2020-09-23 19-51-32](https://user-images.githubusercontent.com/7505980/94044029-4b841f00-fdd6-11ea-9cfc-4ca64dd57056.png)

### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected